### PR TITLE
Pack to a Docker image

### DIFF
--- a/Packerfile.json
+++ b/Packerfile.json
@@ -14,10 +14,29 @@
         "OS_Version": "Ubuntu-12.04",
         "Release": "0.2.2"
       }
+    },{
+      "type": "docker",
+      "image": "phusion/baseimage:0.9.9",
+      "commit": true,
+      "changes": [
+        "EXPOSE 80 8080 9200 5601 8081",
+        "ENTRYPOINT /home/ubuntu/snowplow/docker/entrypoint.sh"
+      ]
     }
   ],
 
   "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "useradd -r ubuntu",
+        "apt-get update",
+        "apt-get install -y wget software-properties-common python-software-properties",
+        "curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -",
+        "sudo apt-get install -y nodejs"
+      ],
+      "only": ["docker"]
+    },
     {
       "type": "shell",
       "script": "scripts/1_setup_dirs_pipes.sh",
@@ -29,9 +48,38 @@
       "destination": "/home/ubuntu/snowplow"
     },
     {
+      "type": "file",
+      "source": "resources/docker",
+      "destination": "/home/ubuntu/snowplow",
+      "only": ["docker"]
+    },
+    {
+      "type": "file",
+      "source": "ui",
+      "destination": "/home/ubuntu/snowplow",
+      "only": ["docker"]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "cd /home/ubuntu/snowplow/ui",
+        "ls",
+        "npm install",
+        "npm run compile"
+      ],
+      "only": ["docker"]
+    },
+    {
       "type": "shell",
       "script": "scripts/2_setup_postgres.sh",
       "execute_command": "chmod +x {{ .Path }}; sh '{{ .Path }}'"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "/etc/init.d/postgresql start"
+      ],
+      "only": ["docker"]
     },
     {
       "type": "shell",
@@ -56,22 +104,26 @@
     {
       "type": "file",
       "source": "ui/index.html",
-      "destination": "/home/ubuntu/snowplow/ui/index.html"
+      "destination": "/home/ubuntu/snowplow/ui/index.html",
+      "only": ["amazon-ebs"]
     },
     {
       "type": "file",
       "source": "ui/dist/snowplow-mini.js",
-      "destination": "/home/ubuntu/snowplow/ui/dist/snowplow-mini.js"
+      "destination": "/home/ubuntu/snowplow/ui/dist/snowplow-mini.js",
+      "only": ["amazon-ebs"]
     },
     {
       "type": "file",
       "source": "ui/assets",
-      "destination": "/home/ubuntu/snowplow/ui"
+      "destination": "/home/ubuntu/snowplow/ui",
+      "only": ["amazon-ebs"]
     },
     {
       "type": "file",
       "source": "ui/node_modules",
-      "destination": "/home/ubuntu/snowplow/ui"
+      "destination": "/home/ubuntu/snowplow/ui",
+      "only": ["amazon-ebs"]
     },
     {
       "type": "shell",
@@ -86,6 +138,11 @@
     {
       "type": "shell",
       "script": "scripts/6_configure.sh",
+      "execute_command": "chmod +x {{ .Path }}; sh '{{ .Path }}'"
+    },
+    {
+      "type": "shell",
+      "script": "scripts/7_cleanup.sh",
       "execute_command": "chmod +x {{ .Path }}; sh '{{ .Path }}'"
     }
   ]

--- a/resources/docker/entrypoint.sh
+++ b/resources/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+/etc/init.d/postgresql start && \
+/etc/init.d/elasticsearch start && \
+/etc/init.d/kibana4_init start && \
+/etc/init.d/snowplow_stream_collector_0.6.0 start && \
+/etc/init.d/snowplow_stream_enrich_0.7.0 start && \
+/etc/init.d/snowplow_elasticsearch_sink_good_0.5.0 start && \
+/etc/init.d/snowplow_elasticsearch_sink_bad_0.5.0 start && \
+/etc/init.d/iglu_server_0.2.0 start && \
+/etc/init.d/nginx start
+
+while true;do sleep 5;done

--- a/scripts/7_cleanup.sh
+++ b/scripts/7_cleanup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+#############
+# Constants #
+#############
+
+main_dir=/home/ubuntu/snowplow
+staging_dir=$main_dir/staging
+
+############################
+# Remove Staging Directory #
+############################
+
+rm -rf $staging_dir

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,9 @@
   "name": "snowplow-mini",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "compile": "tsc -p js --outDir dist/ && browserify dist/SnowplowMiniApp.js -o dist/bundle.js && uglifyjs dist/bundle.js > dist/snowplow-mini.js"
+  },
   "dependencies": {
     "director": "1.2.0",
     "react": "0.14.7",
@@ -12,5 +15,10 @@
   },
   "contributors": [
     "Joshua Beemster"
-  ]
+  ],
+  "devDependencies": {
+    "browserify": "^14.3.0",
+    "typescript": "^2.2.2",
+    "uglifyjs": "^2.4.10"
+  }
 }


### PR DESCRIPTION
I know this isn't the cleanest, and it's not the "dockeryist" way to do this, since we're running all of the services inside one docker container just like the AMI, but I've altered the Packerfile to support building to a docker container.  I think this is super helpful for playing around with snowplow-mini and for local dev scenarios.  I'd love feedback and I'd be glad to help clean this up however you suggest.

I've pushed a compiled image of this out to docker hub at https://hub.docker.com/r/mrosack/snowplow-mini/.