### PR TITLE
Add new docs links, make explicit the version of Mini

### DIFF
--- a/provisioning/resources/ui/index.html
+++ b/provisioning/resources/ui/index.html
@@ -14,7 +14,7 @@
     </header>
     <div class="snowplowminiapp"></div>
     <footer class="footer">
-      <p>COPYRIGHT &#169; 2016-2018 SNOWPLOW ANALYTICS LTD. ALL RIGHTS RESERVED. PRIVACY POLICY.</p>
+      <p>COPYRIGHT &#169; 2016-2020 SNOWPLOW ANALYTICS LTD. ALL RIGHTS RESERVED. PRIVACY POLICY.</p>
     </footer>
 
     <!-- Snowplow starts plowing -->

--- a/provisioning/resources/ui/js/components/Overview.tsx
+++ b/provisioning/resources/ui/js/components/Overview.tsx
@@ -42,12 +42,15 @@ export class Overview extends React.Component<{}, {}> {
         <h3>3. Understanding how Snowplow Mini works</h3>
         <h3>Quicklinks: </h3>
         <ul>
+          <li><a href={'https://docs.snowplowanalytics.com/docs/understanding-your-pipeline/what-is-snowplow-mini'}>What is Snowplow Mini?</a></li>
+          <li><a href={'https://docs.snowplowanalytics.com/docs/open-source-components-and-applications/snowplow-mini/snowplow-mini-0-10-1/usage-guide/'}>Usage guide</a></li>
+          <li><a href={'https://docs.snowplowanalytics.com/docs/open-source-components-and-applications/snowplow-mini/snowplow-mini-0-10-1/control-plane-api/'}>Control Plane API</a></li>
           <li>Link to <a href={'https://github.com/snowplow/snowplow-mini'}>Snowplow Mini</a> repository</li>
-          <li>Link to <a href={'https://github.com/snowplow/snowplow-mini/wiki/Quickstart-guide'}>Quickstart Guide</a></li>
           <li>Collector endpoint <a href={collector}>{collector}</a></li>
         </ul>
         <h3>The software stack installed: </h3>
         <ul>
+          <li><b>Snowplow Mini 0.10.1</b></li>
           <li>Snowplow Stream Collector NSQ 1.0.1</li>
           <li>Snowplow Stream Enrich NSQ 1.3.2</li>
           <li>Snowplow Elasticsearch Loader 1.0.0</li>


### PR DESCRIPTION
This updates the copyright notice as well as some references to the currently running version of SP Mini (ideally this should get moved to a variable along with the other software versions) and some references to the new docs. Resolves #247 