### PR TITLE
Upgrade to latest ca-certificates to workaround expired Nodesource certs

### DIFF
--- a/provisioning/roles/nodejs/tasks/setup-Debian.yml
+++ b/provisioning/roles/nodejs/tasks/setup-Debian.yml
@@ -2,6 +2,9 @@
 - name: Ensure apt-transport-https is installed.
   apt: name=apt-transport-https state=present
 
+- name: Install latest ca-certificates.
+  apt: name=ca-certificates state=latest
+
 - name: Add Nodesource apt key.
   apt_key:
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280


### PR DESCRIPTION
Fix for expired Nodesource cert that causes provisioning of Snowplow Mini to fail.

See for details:
https://github.com/nodesource/distributions/issues/541
https://github.com/nodesource/distributions/issues/1266