### PR TITLE
Fix Caddy installation and synced folder on Windows

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,11 @@ Vagrant.configure("2") do |config|
 
   # Use NFS for shared folders for better performance
   config.vm.network :private_network, ip: '192.168.56.56' # Uncomment to use NFS
-  config.vm.synced_folder '.', '/vagrant', nfs: true # Uncomment to use NFS
+  if Vagrant::Util::Platform.windows? then
+    config.vm.synced_folder '.', '/vagrant' # NFS not supported on Windows
+  else
+    config.vm.synced_folder '.', '/vagrant', nfs: true # Uncomment to use NFS
+  end
 
   config.vm.network "forwarded_port", guest: 80, host: 2000     # Caddy insecure
   config.vm.network "forwarded_port", guest: 8443, host: 2443   # Caddy secure

--- a/provisioning/roles/sp_mini_4_setup_apps/tasks/main.yml
+++ b/provisioning/roles/sp_mini_4_setup_apps/tasks/main.yml
@@ -23,8 +23,8 @@
   become: yes
   shell: |
     apt install -y debian-keyring debian-archive-keyring apt-transport-https
-    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
-    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
     apt update
     apt-get install -y caddy=2.4.6
 


### PR DESCRIPTION
Synced folder that mounts the repository inside the VM were not created on Windows due to NFS not being supported.

>Windows users: NFS folders do not work on Windows hosts. Vagrant will ignore your request for NFS synced folders on Windows.
>https://www.vagrantup.com/docs/synced-folders/nfs

Also Caddy failed to install during provisioning due to GPG key being out of date, so had to update that.

https://caddyserver.com/docs/install#debian-ubuntu-raspbian
