### PR TITLE
Replace Elasticsearch with Opensearch

### DIFF
--- a/provisioning/resources/configs/Caddyfile
+++ b/provisioning/resources/configs/Caddyfile
@@ -39,7 +39,7 @@
     route /kibana* {
         uri strip_prefix /kibana
         header {
-          Content-Security-Policy "default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src data: 'self'"
+          Content-Security-Policy "default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src data: 'self'"
           X-Frame-Options "DENY"
         }
         reverse_proxy localhost:5601 {

--- a/provisioning/resources/configs/compositions/docker-compose-aws.yml
+++ b/provisioning/resources/configs/compositions/docker-compose-aws.yml
@@ -2,17 +2,19 @@ version: "3"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.23
+    image: opensearchproject/opensearch:2.4.0
     container_name: elasticsearch
     restart: always
     environment:
       # Swapping needs to be disabled for performance and node stability
       - "bootstrap.memory_lock=true"
-      - ES_JAVA_OPTS=-Xms${ES_JVM_SIZE} -Xmx${ES_JVM_SIZE}
+      - OPENSEARCH_JAVA_OPTS=-Xms${ES_JVM_SIZE} -Xmx${ES_JVM_SIZE}
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
     volumes:
-      - /home/ubuntu/snowplow/elasticsearch/data:/usr/share/elasticsearch/data
-      - /home/ubuntu/snowplow/elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
-      - /home/ubuntu/snowplow/elasticsearch/config/log4j2.properties:/usr/share/elasticsearch/config/log4j2.properties
+      - /home/ubuntu/snowplow/elasticsearch/data:/usr/share/opensearch/data
+      - /home/ubuntu/snowplow/elasticsearch/config/elasticsearch.yml:/usr/share/opensearch/config/opensearch.yml
+      - /home/ubuntu/snowplow/elasticsearch/config/log4j2.properties:/usr/share/opensearch/config/log4j2.properties
     ulimits:
       memlock:
         soft: -1
@@ -30,11 +32,13 @@ services:
       - "9300:9300"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:6.8.23
+    image: opensearchproject/opensearch-dashboards:2.4.0
     container_name: kibana
     restart: always
+    environment:
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
     volumes:
-      - /home/ubuntu/snowplow/elasticsearch/config/kibana.yml:/usr/share/kibana/config/kibana.yml
+      - /home/ubuntu/snowplow/elasticsearch/config/kibana.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml
     ports:
       - "5601:5601"
     depends_on:
@@ -46,7 +50,7 @@ services:
         awslogs-stream: "kibana"
 
   elasticsearch-loader-good:
-    image: snowplow/elasticsearch-loader:1.0.7
+    image: snowplow/elasticsearch-loader:2.0.8
     container_name: elasticsearch-loader-good
     command: [ "--config", "/snowplow/config/snowplow-es-loader-good.hocon" ]
     restart: always
@@ -63,7 +67,7 @@ services:
       - "JAVA_OPTS=-Xmx${SP_JVM_SIZE} -Dlog4j2.formatMsgNoLookups=true"
 
   elasticsearch-loader-bad:
-    image: snowplow/elasticsearch-loader:1.0.7
+    image: snowplow/elasticsearch-loader:2.0.8
     container_name: elasticsearch-loader-bad
     command: [ "--config", "/snowplow/config/snowplow-es-loader-bad.hocon" ]
     restart: always

--- a/provisioning/resources/configs/compositions/docker-compose-gcp.yml
+++ b/provisioning/resources/configs/compositions/docker-compose-gcp.yml
@@ -2,17 +2,19 @@ version: "3"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.23
+    image: opensearchproject/opensearch:2.4.0
     container_name: elasticsearch
     restart: always
     environment:
       # Swapping needs to be disabled for performance and node stability
       - "bootstrap.memory_lock=true"
-      - ES_JAVA_OPTS=-Xms${ES_JVM_SIZE} -Xmx${ES_JVM_SIZE}
+      - OPENSEARCH_JAVA_OPTS=-Xms${ES_JVM_SIZE} -Xmx${ES_JVM_SIZE}
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
     volumes:
-      - /home/ubuntu/snowplow/elasticsearch/data:/usr/share/elasticsearch/data
-      - /home/ubuntu/snowplow/elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
-      - /home/ubuntu/snowplow/elasticsearch/config/log4j2.properties:/usr/share/elasticsearch/config/log4j2.properties
+      - /home/ubuntu/snowplow/elasticsearch/data:/usr/share/opensearch/data
+      - /home/ubuntu/snowplow/elasticsearch/config/elasticsearch.yml:/usr/share/opensearch/config/opensearch.yml
+      - /home/ubuntu/snowplow/elasticsearch/config/log4j2.properties:/usr/share/opensearch/config/log4j2.properties
     ulimits:
       memlock:
         soft: -1
@@ -27,11 +29,13 @@ services:
       - "9300:9300"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:6.8.23
+    image: opensearchproject/opensearch-dashboards:2.4.0
     container_name: kibana
     restart: always
+    environment:
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
     volumes:
-      - /home/ubuntu/snowplow/elasticsearch/config/kibana.yml:/usr/share/kibana/config/kibana.yml
+      - /home/ubuntu/snowplow/elasticsearch/config/kibana.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml
     ports:
       - "5601:5601"
     depends_on:
@@ -40,7 +44,7 @@ services:
       driver: gcplogs
 
   elasticsearch-loader-good:
-    image: snowplow/elasticsearch-loader:1.0.7
+    image: snowplow/elasticsearch-loader:2.0.8
     container_name: elasticsearch-loader-good
     command: [ "--config", "/snowplow/config/snowplow-es-loader-good.hocon" ]
     restart: always
@@ -54,7 +58,7 @@ services:
       - "JAVA_OPTS=-Xmx${SP_JVM_SIZE} -Dlog4j2.formatMsgNoLookups=true"
 
   elasticsearch-loader-bad:
-    image: snowplow/elasticsearch-loader:1.0.7
+    image: snowplow/elasticsearch-loader:2.0.8
     container_name: elasticsearch-loader-bad
     command: [ "--config", "/snowplow/config/snowplow-es-loader-bad.hocon" ]
     restart: always

--- a/provisioning/resources/configs/snowplow-es-loader-bad.hocon
+++ b/provisioning/resources/configs/snowplow-es-loader-bad.hocon
@@ -11,125 +11,104 @@
 # implied.  See the Apache License Version 2.0 for the specific language
 # governing permissions and limitations there under.
 
-# This file (config.hocon.sample) contains a template with
-# configuration options for the Elasticsearch Loader.
+{
+  "input": {
+    # Sources currently supported are:
+    # "kinesis" for reading records from a Kinesis stream
+    # "stdin" for reading unencoded tab-separated events from stdin
+    # If set to "stdin", JSON documents will not be sent to Elasticsearch
+    # but will be written to stdout.
+    # "nsq" for reading unencoded tab-separated events from NSQ
+    "type": "nsq"
 
-# Sources currently supported are:
-# "kinesis" for reading records from a Kinesis stream
-# "stdin" for reading unencoded tab-separated events from stdin
-# If set to "stdin", JSON documents will not be sent to Elasticsearch
-# but will be written to stdout.
-# "nsq" for reading unencoded tab-separated events from NSQ
-source = "nsq"
+    # Stream name for incoming data
+    "streamName": "BadEnrichedEvents"
 
-# Where to write good and bad records
-sink {
-  # Sinks currently supported are:
-  # "elasticsearch" for writing good records to Elasticsearch
-  # "stdout" for writing good records to stdout
-  good = "elasticsearch"
+    # Channel name for NSQ source
+    # If more than one application reading from the same NSQ topic at the same time,
+    # all of them must have unique channel name for getting all the data from the same topic
+    "channelName": "ESLoaderChannelBad"
 
-  # Sinks currently supported are:
-  # "kinesis" for writing bad records to Kinesis
-  # "stderr" for writing bad records to stderr
-  # "nsq" for writing bad records to NSQ
-  # "none" for ignoring bad records
-  bad = "nsq"
-}
+    # Host name for nsqlookupd
+    "nsqlookupdHost": "nsqlookupd"
 
-# "good" for a stream of successfully enriched events
-# "bad" for a stream of bad events
-# "plain-json" for writing plain json
-enabled = "bad"
+    # HTTP port for nsqd
+    "nsqlookupdPort": 4161
 
-# The following are used to authenticate for the Amazon Kinesis sink.
-#
-# If both are set to "default", the default provider chain is used
-# (see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
-#
-# If both are set to "iam", use AWS IAM Roles to provision credentials.
-#
-# If both are set to "env", use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-aws {
-  accessKey = ""
-  secretKey = ""
-}
-
-queue {
-  # What queue to use, can be "kinesis" or "nsq"
-  enabled="nsq"
-
-  # Config for NSQ
-  # Channel name for NSQ source
-  # If more than one application reading from the same NSQ topic at the same time,
-  # all of them must have unique channel name for getting all the data from the same topic
-  channelName = "ESLoaderChannelBad"
-
-  # Host name for nsqd
-  nsqdHost = "nsqd"
-  # HTTP port for nsqd
-  nsqdPort = 4150
-
-  # Host name for nsqlookupd
-  nsqlookupdHost = "nsqlookupd"
-  # HTTP port for nsqd
-  nsqlookupdPort = 4161
-}
-
-# Common configuration section for all stream sources
-streams {
-  inStreamName = "BadEnrichedEvents"
-
-  # Stream for enriched events which are rejected by Elasticsearch
-  outStreamName = "BadElasticsearchEvents"
-
-  # Events are accumulated in a buffer before being sent to Elasticsearch.
-  # The buffer is emptied whenever:
-  # - the combined size of the stored records exceeds byteLimit or
-  # - the number of stored records exceeds recordLimit or
-  # - the time in milliseconds since it was last emptied exceeds timeLimit
-  buffer {
-    byteLimit = 5242880 # Not supported by NSQ, will be ignored
-    recordLimit = 1
-    timeLimit = 60000 # Not supported by NSQ, will be ignored
-  }
-}
-
-elasticsearch {
-
-  # Events are indexed using an Elasticsearch Client
-  # - endpoint: the cluster endpoint
-  # - port: the port the cluster can be accessed on
-  #   - for http this is usually 9200
-  #   - for transport this is usually 9300
-  # - username (optional, remove if not active): http basic auth username
-  # - password (optional, remove if not active): http basic auth password
-  # - shardDateFormat (optional, remove if not needed): formatting used for sharding good stream, i.e. _yyyy-MM-dd
-  # - shardDateField (optional, if not specified derived_tstamp is used): timestamp field for sharding good stream
-  # - max-timeout: the maximum attempt time before a client restart
-  # - ssl: if using the http client, whether to use ssl or not
-  client {
-    endpoint = "elasticsearch"
-    port = "9200"
-    maxTimeout = "10000"
-    maxRetries = 3
-    ssl = false
+    # Events are accumulated in a buffer before being sent to Elasticsearch.
+    # The buffer is emptied whenever the number of stored records exceeds recordLimit
+    # This value is optional.
+    "buffer": {
+      "recordLimit" = 1
+    }
   }
 
-  # When using the AWS ES service
-  # - signing: if using the http client and the AWS ES service you can sign your requests
-  #    http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
-  # - region where the AWS ES service is located
-  aws {
-    signing = false
-    region = ""
+  "output": {
+    "good": {
+      # Good sinks currently supported are:
+      # "elasticsearch" for writing good records to Elasticsearch
+      # "stdout" for writing good records to stdout
+      # Default value "elasticsearch"
+      "type": "elasticsearch"
+
+      # Events are indexed using an Elasticsearch Client
+      # - endpoint: the cluster endpoint
+      # - port (optional, default value 9200): the port the cluster can be accessed on
+      #   - for http this is usually 9200
+      #   - for transport this is usually 9300
+      # - username (optional, remove if not active): http basic auth username
+      # - password (optional, remove if not active): http basic auth password
+      # - shardDateFormat (optional, remove if not needed): formatting used for sharding good stream, i.e. _yyyy-MM-dd
+      # - shardDateField (optional, if not specified derived_tstamp is used): timestamp field for sharding good stream
+      # - indexTimeout (optional, default value 60000): the maximum time to wait in milliseconds for a single http transaction when indexing events
+      # - maxTimeout (optional, default value 10000): the maximum time to wait in milliseconds between retries after load failures
+      # - maxRetries (optional, default value 6): the maximum number of request attempts before giving up
+      # - ssl (optional, default value false): if using the http client, whether to use ssl or not
+      "client": {
+        "endpoint": "elasticsearch"
+        "port": 9200
+        "maxTimeout" = "10000"
+        "maxRetries" = 3
+        "ssl" = false
+      }
+
+      # When using the AWS ES service
+      # - signing: if using the http client and the AWS ES service you can sign your requests
+      #    http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
+      # - region where the AWS ES service is located
+      # These values are optional.
+      aws {
+        "signing" = false
+        "region" = "eu-central-1"
+      }
+
+      "cluster": {
+        # The Elasticsearch index name
+        # Default value "good"
+        "index": "bad"
+      }
+    }
+    "bad" {
+      # Bad sinks currently supported are:
+      # "kinesis" for writing bad records to Kinesis
+      # "stderr" for writing bad records to stderr
+      # "nsq" for writing bad records to NSQ
+      # "none" for ignoring bad records
+      "type": "nsq"
+
+      # Stream name for events which are rejected by Elasticsearch
+      "streamName": "BadElasticsearchEvents"
+
+      # Host name for nsqd
+      "nsqdHost": "nsqd"
+      # HTTP port for nsqd
+      "nsqdPort": 4150
+    }
   }
 
-  # index: the Elasticsearch index name
-  # type: the Elasticsearch index type
-  cluster {
-    name = "elasticsearch"
-    index = "bad"
-    documentType = "bad"
-  }
+  # "ENRICHED_EVENTS" for a stream of successfully enriched events
+  # "BAD_ROWS" for a stream of bad events
+  # "JSON" for writing plain json
+  "purpose": "BAD_ROWS"
 }
+

--- a/provisioning/resources/configs/snowplow-es-loader-good.hocon
+++ b/provisioning/resources/configs/snowplow-es-loader-good.hocon
@@ -11,125 +11,104 @@
 # implied.  See the Apache License Version 2.0 for the specific language
 # governing permissions and limitations there under.
 
-# This file (config.hocon.sample) contains a template with
-# configuration options for the Elasticsearch Loader.
+{
+  "input": {
+    # Sources currently supported are:
+    # "kinesis" for reading records from a Kinesis stream
+    # "stdin" for reading unencoded tab-separated events from stdin
+    # If set to "stdin", JSON documents will not be sent to Elasticsearch
+    # but will be written to stdout.
+    # "nsq" for reading unencoded tab-separated events from NSQ
+    "type": "nsq"
 
-# Sources currently supported are:
-# "kinesis" for reading records from a Kinesis stream
-# "stdin" for reading unencoded tab-separated events from stdin
-# If set to "stdin", JSON documents will not be sent to Elasticsearch
-# but will be written to stdout.
-# "nsq" for reading unencoded tab-separated events from NSQ
-source = "nsq"
+    # Stream name for incoming data
+    "streamName": "EnrichedEvents"
 
-# Where to write good and bad records
-sink {
-  # Sinks currently supported are:
-  # "elasticsearch" for writing good records to Elasticsearch
-  # "stdout" for writing good records to stdout
-  good = "elasticsearch"
+    # Channel name for NSQ source
+    # If more than one application reading from the same NSQ topic at the same time,
+    # all of them must have unique channel name for getting all the data from the same topic
+    "channelName": "ESLoaderChannelGood"
 
-  # Sinks currently supported are:
-  # "kinesis" for writing bad records to Kinesis
-  # "stderr" for writing bad records to stderr
-  # "nsq" for writing bad records to NSQ
-  # "none" for ignoring bad records
-  bad = "nsq"
-}
+    # Host name for nsqlookupd
+    "nsqlookupdHost": "nsqlookupd"
 
-# "good" for a stream of successfully enriched events
-# "bad" for a stream of bad events
-# "plain-json" for writing plain json
-enabled = "good"
+    # HTTP port for nsqd
+    "nsqlookupdPort": 4161
 
-# The following are used to authenticate for the Amazon Kinesis sink.
-#
-# If both are set to "default", the default provider chain is used
-# (see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
-#
-# If both are set to "iam", use AWS IAM Roles to provision credentials.
-#
-# If both are set to "env", use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-aws {
-  accessKey = ""
-  secretKey = ""
-}
-
-queue {
-  # What queue to use, can be "kinesis" or "nsq"
-  enabled="nsq"
-
-  # Config for NSQ
-  # Channel name for NSQ source
-  # If more than one application reading from the same NSQ topic at the same time,
-  # all of them must have unique channel name for getting all the data from the same topic
-  channelName = "ESLoaderChannelGood"
-
-  # Host name for nsqd
-  nsqdHost = "nsqd"
-  # HTTP port for nsqd
-  nsqdPort = 4150
-
-  # Host name for nsqlookupd
-  nsqlookupdHost = "nsqlookupd"
-  # HTTP port for nsqd
-  nsqlookupdPort = 4161
-}
-
-# Common configuration section for all stream sources
-streams {
-  inStreamName = "EnrichedEvents"
-
-  # Stream for enriched events which are rejected by Elasticsearch
-  outStreamName = "BadElasticsearchEvents"
-
-  # Events are accumulated in a buffer before being sent to Elasticsearch.
-  # The buffer is emptied whenever:
-  # - the combined size of the stored records exceeds byteLimit or
-  # - the number of stored records exceeds recordLimit or
-  # - the time in milliseconds since it was last emptied exceeds timeLimit
-  buffer {
-    byteLimit = 5242880 # Not supported by NSQ, will be ignored
-    recordLimit = 1
-    timeLimit = 60000 # Not supported by NSQ, will be ignored
-  }
-}
-
-elasticsearch {
-
-  # Events are indexed using an Elasticsearch Client
-  # - endpoint: the cluster endpoint
-  # - port: the port the cluster can be accessed on
-  #   - for http this is usually 9200
-  #   - for transport this is usually 9300
-  # - username (optional, remove if not active): http basic auth username
-  # - password (optional, remove if not active): http basic auth password
-  # - shardDateFormat (optional, remove if not needed): formatting used for sharding good stream, i.e. _yyyy-MM-dd
-  # - shardDateField (optional, if not specified derived_tstamp is used): timestamp field for sharding good stream
-  # - max-timeout: the maximum attempt time before a client restart
-  # - ssl: if using the http client, whether to use ssl or not
-  client {
-    endpoint = "elasticsearch"
-    port = "9200"
-    maxTimeout = "10000"
-    maxRetries = 3
-    ssl = false
+    # Events are accumulated in a buffer before being sent to Elasticsearch.
+    # The buffer is emptied whenever the number of stored records exceeds recordLimit
+    # This value is optional.
+    "buffer": {
+      "recordLimit" = 1
+    }
   }
 
-  # When using the AWS ES service
-  # - signing: if using the http client and the AWS ES service you can sign your requests
-  #    http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
-  # - region where the AWS ES service is located
-  aws {
-    signing = false
-    region = ""
+  "output": {
+    "good": {
+      # Good sinks currently supported are:
+      # "elasticsearch" for writing good records to Elasticsearch
+      # "stdout" for writing good records to stdout
+      # Default value "elasticsearch"
+      "type": "elasticsearch"
+
+      # Events are indexed using an Elasticsearch Client
+      # - endpoint: the cluster endpoint
+      # - port (optional, default value 9200): the port the cluster can be accessed on
+      #   - for http this is usually 9200
+      #   - for transport this is usually 9300
+      # - username (optional, remove if not active): http basic auth username
+      # - password (optional, remove if not active): http basic auth password
+      # - shardDateFormat (optional, remove if not needed): formatting used for sharding good stream, i.e. _yyyy-MM-dd
+      # - shardDateField (optional, if not specified derived_tstamp is used): timestamp field for sharding good stream
+      # - indexTimeout (optional, default value 60000): the maximum time to wait in milliseconds for a single http transaction when indexing events
+      # - maxTimeout (optional, default value 10000): the maximum time to wait in milliseconds between retries after load failures
+      # - maxRetries (optional, default value 6): the maximum number of request attempts before giving up
+      # - ssl (optional, default value false): if using the http client, whether to use ssl or not
+      "client": {
+        "endpoint": "elasticsearch"
+        "port": 9200
+        "maxTimeout" = "10000"
+        "maxRetries" = 3
+        "ssl" = false
+      }
+
+      # When using the AWS ES service
+      # - signing: if using the http client and the AWS ES service you can sign your requests
+      #    http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
+      # - region where the AWS ES service is located
+      # These values are optional.
+      aws {
+        "signing" = false
+        "region" = "eu-central-1"
+      }
+
+      "cluster": {
+        # The Elasticsearch index name
+        # Default value "good"
+        "index": "good"
+      }
+    }
+    "bad" {
+      # Bad sinks currently supported are:
+      # "kinesis" for writing bad records to Kinesis
+      # "stderr" for writing bad records to stderr
+      # "nsq" for writing bad records to NSQ
+      # "none" for ignoring bad records
+      "type": "nsq"
+
+      # Stream name for events which are rejected by Elasticsearch
+      "streamName": "BadElasticsearchEvents"
+
+      # Host name for nsqd
+      "nsqdHost": "nsqd"
+      # HTTP port for nsqd
+      "nsqdPort": 4150
+    }
   }
 
-  # index: the Elasticsearch index name
-  # type: the Elasticsearch index type
-  cluster {
-    name = "elasticsearch"
-    index = "good"
-    documentType = "good"
-  }
+  # "ENRICHED_EVENTS" for a stream of successfully enriched events
+  # "BAD_ROWS" for a stream of bad events
+  # "JSON" for writing plain json
+  "purpose": "ENRICHED_EVENTS"
 }
+

--- a/provisioning/resources/elasticsearch/config/elasticsearch.yml
+++ b/provisioning/resources/elasticsearch/config/elasticsearch.yml
@@ -1,15 +1,3 @@
-# ======================== Elasticsearch Configuration =========================
-#
-# NOTE: Elasticsearch comes with reasonable defaults for most settings.
-#       Before you set out to tweak and tune the configuration, make sure you
-#       understand what are you trying to accomplish and the consequences.
-#
-# The primary way of configuring a node is via this file. This template lists
-# the most important settings you may want to configure for a production cluster.
-#
-# Please consult the documentation for further information on configuration options:
-# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
-#
 # ---------------------------------- Cluster -----------------------------------
 #
 # Use a descriptive name for your cluster:
@@ -28,6 +16,6 @@ node.name: "sp-mini-es-node"
 network.host: 0.0.0.0
 # --------------------------------- Discovery ----------------------------------
 #
-# Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
+# Specifies whether it should form a multiple-node cluster:
 #
-discovery.zen.minimum_master_nodes: 1
+discovery.type: single-node

--- a/provisioning/resources/elasticsearch/config/kibana.yml
+++ b/provisioning/resources/elasticsearch/config/kibana.yml
@@ -4,7 +4,7 @@ server.port: 5601
 # Specifies the address to which the Kibana server will bind. IP addresses and host names are both valid values.
 # The default is 'localhost', which usually means remote machines will not be able to connect.
 # To allow connections from remote users, set this parameter to a non-loopback address.
-server.host: "0"
+server.host: "0.0.0.0"
 
 # Enables you to specify a path to mount Kibana at if you are running behind a proxy.
 # Use the `server.rewriteBasePath` setting to tell Kibana if it should remove the basePath
@@ -25,7 +25,7 @@ server.rewriteBasePath: false
 server.name: "kibana"
 
 # The URL of the Elasticsearch instance to use for all your queries.
-elasticsearch.url: http://elasticsearch:9200
+opensearch.hosts: ["http://elasticsearch:9200"]
 
 # When this setting's value is true Kibana uses the hostname specified in the server.host
 # setting. When the value of this setting is false, Kibana uses the hostname of the host
@@ -34,81 +34,7 @@ elasticsearch.url: http://elasticsearch:9200
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations and
 # dashboards. Kibana creates a new index if the index doesn't already exist.
-kibana.index: ".kibana"
+opensearchDashboards.index: ".opensearch_dashboards"
 
 # The default application to load.
-kibana.defaultAppId: "discover"
-
-# If your Elasticsearch is protected with basic authentication, these settings provide
-# the username and password that the Kibana server uses to perform maintenance on the Kibana
-# index at startup. Your Kibana users still need to authenticate with Elasticsearch, which
-# is proxied through the Kibana server.
-#elasticsearch.username: "user"
-#elasticsearch.password: "pass"
-
-# Enables SSL and paths to the PEM-format SSL certificate and SSL key files, respectively.
-# These settings enable SSL for outgoing requests from the Kibana server to the browser.
-#server.ssl.enabled: false
-#server.ssl.certificate: /path/to/your/server.crt
-#server.ssl.key: /path/to/your/server.key
-
-# Optional settings that provide the paths to the PEM-format SSL certificate and key files.
-# These files validate that your Elasticsearch backend uses the same key files.
-#elasticsearch.ssl.certificate: /path/to/your/client.crt
-#elasticsearch.ssl.key: /path/to/your/client.key
-
-# Optional setting that enables you to specify a path to the PEM file for the certificate
-# authority for your Elasticsearch instance.
-#elasticsearch.ssl.certificateAuthorities: [ "/path/to/your/CA.pem" ]
-
-# To disregard the validity of SSL certificates, change this setting's value to 'none'.
-#elasticsearch.ssl.verificationMode: full
-
-# Time in milliseconds to wait for Elasticsearch to respond to pings. Defaults to the value of
-# the elasticsearch.requestTimeout setting.
-#elasticsearch.pingTimeout: 1500
-
-# Time in milliseconds to wait for responses from the back end or Elasticsearch. This value
-# must be a positive integer.
-#elasticsearch.requestTimeout: 30000
-
-# List of Kibana client-side headers to send to Elasticsearch. To send *no* client-side
-# headers, set this value to [] (an empty list).
-#elasticsearch.requestHeadersWhitelist: [ authorization ]
-
-# Header names and values that are sent to Elasticsearch. Any custom headers cannot be overwritten
-# by client-side headers, regardless of the elasticsearch.requestHeadersWhitelist configuration.
-#elasticsearch.customHeaders: {}
-
-# Time in milliseconds for Elasticsearch to wait for responses from shards. Set to 0 to disable.
-#elasticsearch.shardTimeout: 30000
-
-# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying.
-#elasticsearch.startupTimeout: 5000
-
-# Logs queries sent to Elasticsearch. Requires logging.verbose set to true.
-#elasticsearch.logQueries: false
-
-# Specifies the path where Kibana creates the process ID file.
-#pid.file: /var/run/kibana.pid
-
-# Enables you specify a file where Kibana stores log output.
-#logging.dest: stdout
-
-# Set the value of this setting to true to suppress all logging output.
-#logging.silent: false
-
-# Set the value of this setting to true to suppress all logging output other than error messages.
-#logging.quiet: false
-
-# Set the value of this setting to true to log all events, including system usage information
-# and all requests.
-#logging.verbose: false
-
-# Set the interval in milliseconds to sample system and process performance
-# metrics. Minimum is 100ms. Defaults to 5000.
-#ops.interval: 5000
-
-# The default locale. This locale can be used in certain circumstances to substitute any missing
-# translations.
-#i18n.defaultLocale: "en"
+opensearchDashboards.defaultAppId: "discover"

--- a/provisioning/resources/elasticsearch/mapping/bad-mapping.json
+++ b/provisioning/resources/elasticsearch/mapping/bad-mapping.json
@@ -13,1088 +13,1086 @@
     }
   },
   "mappings": {
-    "bad": {
-      "properties": {
-        "schema": {
-          "type": "keyword"
-        },
-        "data": {
-          "properties": {
-            "failure": {
-              "properties": {
-                "actualSizeBytes": {
-                  "type": "long"
-                },
-                "error": {
-                  "properties": {
-                    "location": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
+    "properties": {
+      "schema": {
+        "type": "keyword"
+      },
+      "data": {
+        "properties": {
+          "failure": {
+            "properties": {
+              "actualSizeBytes": {
+                "type": "long"
+              },
+              "error": {
+                "properties": {
+                  "location": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
                     },
-                    "message": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
+                    "type": "text"
+                  },
+                  "message": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
                     },
-                    "reason": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    }
+                    "type": "text"
+                  },
+                  "reason": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  }
+                }
+              },
+              "errors": {
+                "properties": {
+                  "key": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "message": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "type": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "value": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  }
+                }
+              },
+              "expectation": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
                   }
                 },
-                "errors": {
-                  "properties": {
-                    "key": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
+                "type": "text"
+              },
+              "fieldCount": {
+                "type": "long"
+              },
+              "loader": {
+                "type": "keyword"
+              },
+              "maximumAllowedSizeBytes": {
+                "type": "long"
+              },
+              "message": {
+                "properties": {
+                  "error": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
                     },
-                    "message": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
+                    "type": "text"
+                  },
+                  "expectation": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
                     },
-                    "type": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
+                    "type": "text"
+                  },
+                  "payloadField": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
                     },
-                    "value": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    }
+                    "type": "text"
+                  },
+                  "value": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
                   }
-                },
-                "expectation": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
+                }
+              },
+              "messages": {
+                "type": "nested",
+                "properties": {
+                  "actual": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "enrichment": {
+                    "properties": {
+                      "identifier": {
+                        "type": "keyword"
+                      },
+                      "schemaKey": {
+                        "type": "keyword"
+                      }
                     }
                   },
-                  "type": "text"
-                },
-                "fieldCount": {
-                  "type": "long"
-                },
-                "loader": {
-                  "type": "keyword"
-                },
-                "maximumAllowedSizeBytes": {
-                  "type": "long"
-                },
-                "message": {
-                  "properties": {
-                    "error": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "expectation": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "payloadField": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "value": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    }
-                  }
-                },
-                "messages": {
-                  "type": "nested",
-                  "properties": {
-                    "actual": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "enrichment": {
-                      "properties": {
-                        "identifier": {
-                          "type": "keyword"
-                        },
-                        "schemaKey": {
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "error": {
-                      "properties": {
-                        "dataReports": {
-                          "properties": {
-                            "keyword": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
+                  "error": {
+                    "properties": {
+                      "dataReports": {
+                        "properties": {
+                          "keyword": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                              }
                             },
-                            "message": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
-                            },
-                            "path": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
-                            },
-                            "targets": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
-                            }
-                          }
-                        },
-                        "error": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
+                            "type": "text"
                           },
-                          "type": "text"
-                        },
-                        "lookupHistory": {
-                          "type": "nested",
-                          "properties": {
-                            "attempts": {
-                              "type": "long"
-                            },
-                            "errors": {
-                              "type": "nested",
-                              "properties": {
-                                "error": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "text"
-                                },
-                                "message": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "text"
-                                }
+                          "message": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
                               }
                             },
-                            "lastAttempt": {
-                              "type": "date"
-                            },
-                            "repository": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
-                            }
-                          }
-                        },
-                        "schemaIssues": {
-                          "type": "nested",
-                          "properties": {
-                            "message": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
-                            },
-                            "path": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "error_str": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "expectation": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "expectedMapping": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "field": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "json": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "message": {
-                      "properties": {
-                        "error": {
-                          "properties": {
-                            "dataReports": {
-                              "type": "nested",
-                              "properties": {
-                                "keyword": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "text"
-                                },
-                                "message": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "text"
-                                },
-                                "path": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "text"
-                                },
-                                "targets": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "text"
-                                }
+                            "type": "text"
+                          },
+                          "path": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
                               }
                             },
-                            "error": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
+                            "type": "text"
+                          },
+                          "targets": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                              }
                             },
-                            "lookupHistory": {
-                              "properties": {
-                                "attempts": {
-                                  "type": "long"
-                                },
-                                "errors": {
-                                  "properties": {
-                                    "error": {
-                                      "fields": {
-                                        "keyword": {
-                                          "ignore_above": 256,
-                                          "type": "keyword"
-                                        }
-                                      },
-                                      "type": "text"
-                                    },
-                                    "message": {
-                                      "fields": {
-                                        "keyword": {
-                                          "ignore_above": 256,
-                                          "type": "keyword"
-                                        }
-                                      },
-                                      "type": "text"
-                                    }
+                            "type": "text"
+                          }
+                        }
+                      },
+                      "error": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      },
+                      "lookupHistory": {
+                        "type": "nested",
+                        "properties": {
+                          "attempts": {
+                            "type": "long"
+                          },
+                          "errors": {
+                            "type": "nested",
+                            "properties": {
+                              "error": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
                                   }
                                 },
-                                "lastAttempt": {
-                                  "type": "date"
+                                "type": "text"
+                              },
+                              "message": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                  }
                                 },
-                                "repository": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "text"
-                                }
+                                "type": "text"
+                              }
+                            }
+                          },
+                          "lastAttempt": {
+                            "type": "date"
+                          },
+                          "repository": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
                               }
                             },
-                            "schemaIssues": {
-                              "type": "nested",
-                              "properties": {
-                                "message": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "text"
+                            "type": "text"
+                          }
+                        }
+                      },
+                      "schemaIssues": {
+                        "type": "nested",
+                        "properties": {
+                          "message": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                              }
+                            },
+                            "type": "text"
+                          },
+                          "path": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                              }
+                            },
+                            "type": "text"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "error_str": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "expectation": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "expectedMapping": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "field": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "json": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "message": {
+                    "properties": {
+                      "error": {
+                        "properties": {
+                          "dataReports": {
+                            "type": "nested",
+                            "properties": {
+                              "keyword": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                  }
                                 },
-                                "path": {
-                                  "fields": {
-                                    "keyword": {
-                                      "ignore_above": 256,
-                                      "type": "keyword"
-                                    }
+                                "type": "text"
+                              },
+                              "message": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                  }
+                                },
+                                "type": "text"
+                              },
+                              "path": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                  }
+                                },
+                                "type": "text"
+                              },
+                              "targets": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                  }
+                                },
+                                "type": "text"
+                              }
+                            }
+                          },
+                          "error": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                              }
+                            },
+                            "type": "text"
+                          },
+                          "lookupHistory": {
+                            "properties": {
+                              "attempts": {
+                                "type": "long"
+                              },
+                              "errors": {
+                                "properties": {
+                                  "error": {
+                                    "fields": {
+                                      "keyword": {
+                                        "ignore_above": 256,
+                                        "type": "keyword"
+                                      }
+                                    },
+                                    "type": "text"
                                   },
-                                  "type": "text"
+                                  "message": {
+                                    "fields": {
+                                      "keyword": {
+                                        "ignore_above": 256,
+                                        "type": "keyword"
+                                      }
+                                    },
+                                    "type": "text"
+                                  }
                                 }
+                              },
+                              "lastAttempt": {
+                                "type": "date"
+                              },
+                              "repository": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                  }
+                                },
+                                "type": "text"
+                              }
+                            }
+                          },
+                          "schemaIssues": {
+                            "type": "nested",
+                            "properties": {
+                              "message": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                  }
+                                },
+                                "type": "text"
+                              },
+                              "path": {
+                                "fields": {
+                                  "keyword": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                  }
+                                },
+                                "type": "text"
                               }
                             }
                           }
-                        },
-                        "error_str": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        },
-                        "expectation": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        },
-                        "field": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        },
-                        "schemaKey": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        },
-                        "value": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        }
-                      }
-                    },
-                    "schemaCriterion": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
                         }
                       },
-                      "type": "text"
-                    },
-                    "schemaKey": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "value": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    }
-                  }
-                },
-                "timestamp": {
-                  "type": "date"
-                },
-                "type": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "vendor": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "version": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                }
-              }
-            },
-            "failure_list": {
-              "properties": {
-                "error": {
-                  "properties": {
-                    "dataReports": {
-                      "type": "nested",
-                      "properties": {
-                        "keyword": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        },
-                        "message": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        },
-                        "path": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        },
-                        "targets": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        }
-                      }
-                    },
-                    "error": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "lookupHistory": {
-                      "properties": {
-                        "attempts": {
-                          "type": "long"
-                        },
-                        "errors": {
-                          "properties": {
-                            "error": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
-                            },
-                            "message": {
-                              "fields": {
-                                "keyword": {
-                                  "ignore_above": 256,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "text"
-                            }
+                      "error_str": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
                           }
                         },
-                        "lastAttempt": {
-                          "type": "date"
+                        "type": "text"
+                      },
+                      "expectation": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
                         },
-                        "repository": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
-                        }
+                        "type": "text"
+                      },
+                      "field": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      },
+                      "schemaKey": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      },
+                      "value": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      }
+                    }
+                  },
+                  "schemaCriterion": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
                       }
                     },
-                    "schemaIssues": {
-                      "type": "nested",
-                      "properties": {
-                        "message": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "text"
+                    "type": "text"
+                  },
+                  "schemaKey": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "value": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  }
+                }
+              },
+              "timestamp": {
+                "type": "date"
+              },
+              "type": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "vendor": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "version": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              }
+            }
+          },
+          "failure_list": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "dataReports": {
+                    "type": "nested",
+                    "properties": {
+                      "keyword": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
                         },
-                        "path": {
-                          "fields": {
-                            "keyword": {
-                              "ignore_above": 256,
-                              "type": "keyword"
-                            }
+                        "type": "text"
+                      },
+                      "message": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      },
+                      "path": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      },
+                      "targets": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      }
+                    }
+                  },
+                  "error": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "lookupHistory": {
+                    "properties": {
+                      "attempts": {
+                        "type": "long"
+                      },
+                      "errors": {
+                        "properties": {
+                          "error": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                              }
+                            },
+                            "type": "text"
                           },
-                          "type": "text"
+                          "message": {
+                            "fields": {
+                              "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                              }
+                            },
+                            "type": "text"
+                          }
                         }
+                      },
+                      "lastAttempt": {
+                        "type": "date"
+                      },
+                      "repository": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      }
+                    }
+                  },
+                  "schemaIssues": {
+                    "type": "nested",
+                    "properties": {
+                      "message": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
+                      },
+                      "path": {
+                        "fields": {
+                          "keyword": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "text"
                       }
                     }
                   }
-                },
-                "expected": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "key": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "message": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "schemaCriterion": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "schemaKey": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "value": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                }
-              }
-            },
-            "failure_str": {
-              "fields": {
-                "keyword": {
-                  "ignore_above": 256,
-                  "type": "keyword"
                 }
               },
-              "type": "text"
-            },
-            "payload": {
-              "properties": {
-                "body": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "collector": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "collector_tstamp": {
-                  "type": "date"
-                },
-                "contentType": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "contexts": {
-                  "type": "object"
-                },
-                "derived_contexts": {
-                  "type": "object"
-                },
-                "encoding": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "enriched": {
-                  "properties": {
-                    "collector_tstamp": {
-                      "type": "text"
-                    },
-                    "v_collector": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "v_etl": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    }
+              "expected": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
                   }
                 },
-                "event_id": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "headers": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "hostname": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "ipAddress": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "networkUserId": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "querystring": {
-                  "properties": {
-                    "name": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "value": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    }
+                "type": "text"
+              },
+              "key": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
                   }
                 },
-                "raw": {
-                  "properties": {
-                    "contentType": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "encoding": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "headers": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "hostname": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "ipAddress": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "loaderName": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "parameters": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "refererUri": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "timestamp": {
-                      "type": "date"
-                    },
-                    "userId": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "useragent": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "vendor": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    },
-                    "version": {
-                      "fields": {
-                        "keyword": {
-                          "ignore_above": 256,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "text"
-                    }
+                "type": "text"
+              },
+              "message": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
                   }
                 },
-                "refererUri": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
+                "type": "text"
+              },
+              "schemaCriterion": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
                 },
-                "timestamp": {
-                  "type": "date"
+                "type": "text"
+              },
+              "schemaKey": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
                 },
-                "useragent": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
+                "type": "text"
+              },
+              "value": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
                 },
-                "v_collector": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "v_etl": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "vendor": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                },
-                "version": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
-                }
+                "type": "text"
+              }
+            }
+          },
+          "failure_str": {
+            "fields": {
+              "keyword": {
+                "ignore_above": 256,
+                "type": "keyword"
               }
             },
-            "payload_str": {
-              "fields": {
-                "keyword": {
-                  "ignore_above": 256,
-                  "type": "keyword"
+            "type": "text"
+          },
+          "payload": {
+            "properties": {
+              "body": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "collector": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "collector_tstamp": {
+                "type": "date"
+              },
+              "contentType": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "contexts": {
+                "type": "object"
+              },
+              "derived_contexts": {
+                "type": "object"
+              },
+              "encoding": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "enriched": {
+                "properties": {
+                  "collector_tstamp": {
+                    "type": "text"
+                  },
+                  "v_collector": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "v_etl": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  }
                 }
               },
-              "type": "text"
-            },
-            "processor": {
-              "properties": {
-                "artifact": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "text"
+              "event_id": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
                 },
-                "version": {
-                  "fields": {
-                    "keyword": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    }
+                "type": "text"
+              },
+              "headers": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "hostname": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "ipAddress": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "networkUserId": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "querystring": {
+                "properties": {
+                  "name": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
                   },
-                  "type": "text"
+                  "value": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  }
                 }
+              },
+              "raw": {
+                "properties": {
+                  "contentType": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "encoding": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "headers": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "hostname": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "ipAddress": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "loaderName": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "parameters": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "refererUri": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "timestamp": {
+                    "type": "date"
+                  },
+                  "userId": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "useragent": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "vendor": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  },
+                  "version": {
+                    "fields": {
+                      "keyword": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "text"
+                  }
+                }
+              },
+              "refererUri": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "timestamp": {
+                "type": "date"
+              },
+              "useragent": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "v_collector": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "v_etl": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "vendor": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "version": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              }
+            }
+          },
+          "payload_str": {
+            "fields": {
+              "keyword": {
+                "ignore_above": 256,
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "processor": {
+            "properties": {
+              "artifact": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "version": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
               }
             }
           }

--- a/provisioning/resources/elasticsearch/mapping/good-mapping.json
+++ b/provisioning/resources/elasticsearch/mapping/good-mapping.json
@@ -13,307 +13,305 @@
         }
     },
     "mappings": {
-        "good": {
-            "properties": {
-                "app_id": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "br_colordepth": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "br_cookies": {
-                    "type": "boolean"
-                },
-                "br_family": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "br_features_director": {
-                    "type": "boolean"
-                },
-                "br_features_flash": {
-                    "type": "boolean"
-                },
-                "br_features_gears": {
-                    "type": "boolean"
-                },
-                "br_features_java": {
-                    "type": "boolean"
-                },
-                "br_features_pdf": {
-                    "type": "boolean"
-                },
-                "br_features_quicktime": {
-                    "type": "boolean"
-                },
-                "br_features_realplayer": {
-                    "type": "boolean"
-                },
-                "br_features_silverlight": {
-                    "type": "boolean"
-                },
-                "br_features_windowsmedia": {
-                    "type": "boolean"
-                },
-                "br_lang": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "br_name": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "br_renderengine": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "br_type": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "br_version": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "br_viewheight": {
-                    "type": "long"
-                },
-                "br_viewwidth": {
-                    "type": "long"
-                },
-                "collector_tstamp": {
-                    "type": "date",
-                    "format": "dateOptionalTime"
-                },
-                "doc_charset": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "doc_height": {
-                    "type": "long"
-                },
-                "doc_width": {
-                    "type": "long"
-                },
-                "domain_sessionid": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "domain_sessionidx": {
-                    "type": "long"
-                },
-                "domain_userid": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "dvce_ismobile": {
-                    "type": "boolean"
-                },
-                "dvce_screenheight": {
-                    "type": "long"
-                },
-                "dvce_screenwidth": {
-                    "type": "long"
-                },
-                "dvce_sent_tstamp": {
-                    "type": "date",
-                    "format": "dateOptionalTime"
-                },
-                "dvce_tstamp": {
-                    "type": "date",
-                    "format": "dateOptionalTime"
-                },
-                "dvce_type": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "etl_tstamp": {
-                    "type": "date",
-                    "format": "dateOptionalTime"
-                },
-                "event": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "event_id": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "geo_location": {
-                    "type": "geo_point"
-                },
-                "mkt_campaign": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "mkt_content": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "mkt_medium": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "mkt_source": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "mkt_term": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "name_tracker": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "network_userid": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "os_family": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "os_manufacturer": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "os_name": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "os_timezone": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "page_referrer": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "page_title": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "page_url": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "page_urlfragment": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "page_urlhost": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "page_urlpath": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "page_urlport": {
-                    "type": "long"
-                },
-                "page_urlquery": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "page_urlscheme": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "platform": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "pp_xoffset_max": {
-                    "type": "long"
-                },
-                "pp_xoffset_min": {
-                    "type": "long"
-                },
-                "pp_yoffset_max": {
-                    "type": "long"
-                },
-                "pp_yoffset_min": {
-                    "type": "long"
-                },
-                "refr_medium": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "refr_source": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "refr_term": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "refr_urlfragment": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "refr_urlhost": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "refr_urlpath": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "refr_urlport": {
-                    "type": "long"
-                },
-                "refr_urlquery": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "refr_urlscheme": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "se_action": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "se_category": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "se_label": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "user_fingerprint": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "user_id": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "user_ipaddress": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "useragent": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "v_collector": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "v_etl": {
-                    "type": "keyword",
-                    "index": true
-                },
-                "v_tracker": {
-                    "type": "keyword",
-                    "index": true
-                }
+        "properties": {
+            "app_id": {
+                "type": "keyword",
+                "index": true
+            },
+            "br_colordepth": {
+                "type": "keyword",
+                "index": true
+            },
+            "br_cookies": {
+                "type": "boolean"
+            },
+            "br_family": {
+                "type": "keyword",
+                "index": true
+            },
+            "br_features_director": {
+                "type": "boolean"
+            },
+            "br_features_flash": {
+                "type": "boolean"
+            },
+            "br_features_gears": {
+                "type": "boolean"
+            },
+            "br_features_java": {
+                "type": "boolean"
+            },
+            "br_features_pdf": {
+                "type": "boolean"
+            },
+            "br_features_quicktime": {
+                "type": "boolean"
+            },
+            "br_features_realplayer": {
+                "type": "boolean"
+            },
+            "br_features_silverlight": {
+                "type": "boolean"
+            },
+            "br_features_windowsmedia": {
+                "type": "boolean"
+            },
+            "br_lang": {
+                "type": "keyword",
+                "index": true
+            },
+            "br_name": {
+                "type": "keyword",
+                "index": true
+            },
+            "br_renderengine": {
+                "type": "keyword",
+                "index": true
+            },
+            "br_type": {
+                "type": "keyword",
+                "index": true
+            },
+            "br_version": {
+                "type": "keyword",
+                "index": true
+            },
+            "br_viewheight": {
+                "type": "long"
+            },
+            "br_viewwidth": {
+                "type": "long"
+            },
+            "collector_tstamp": {
+                "type": "date",
+                "format": "dateOptionalTime"
+            },
+            "doc_charset": {
+                "type": "keyword",
+                "index": true
+            },
+            "doc_height": {
+                "type": "long"
+            },
+            "doc_width": {
+                "type": "long"
+            },
+            "domain_sessionid": {
+                "type": "keyword",
+                "index": true
+            },
+            "domain_sessionidx": {
+                "type": "long"
+            },
+            "domain_userid": {
+                "type": "keyword",
+                "index": true
+            },
+            "dvce_ismobile": {
+                "type": "boolean"
+            },
+            "dvce_screenheight": {
+                "type": "long"
+            },
+            "dvce_screenwidth": {
+                "type": "long"
+            },
+            "dvce_sent_tstamp": {
+                "type": "date",
+                "format": "dateOptionalTime"
+            },
+            "dvce_tstamp": {
+                "type": "date",
+                "format": "dateOptionalTime"
+            },
+            "dvce_type": {
+                "type": "keyword",
+                "index": true
+            },
+            "etl_tstamp": {
+                "type": "date",
+                "format": "dateOptionalTime"
+            },
+            "event": {
+                "type": "keyword",
+                "index": true
+            },
+            "event_id": {
+                "type": "keyword",
+                "index": true
+            },
+            "geo_location": {
+                "type": "geo_point"
+            },
+            "mkt_campaign": {
+                "type": "keyword",
+                "index": true
+            },
+            "mkt_content": {
+                "type": "keyword",
+                "index": true
+            },
+            "mkt_medium": {
+                "type": "keyword",
+                "index": true
+            },
+            "mkt_source": {
+                "type": "keyword",
+                "index": true
+            },
+            "mkt_term": {
+                "type": "keyword",
+                "index": true
+            },
+            "name_tracker": {
+                "type": "keyword",
+                "index": true
+            },
+            "network_userid": {
+                "type": "keyword",
+                "index": true
+            },
+            "os_family": {
+                "type": "keyword",
+                "index": true
+            },
+            "os_manufacturer": {
+                "type": "keyword",
+                "index": true
+            },
+            "os_name": {
+                "type": "keyword",
+                "index": true
+            },
+            "os_timezone": {
+                "type": "keyword",
+                "index": true
+            },
+            "page_referrer": {
+                "type": "keyword",
+                "index": true
+            },
+            "page_title": {
+                "type": "keyword",
+                "index": true
+            },
+            "page_url": {
+                "type": "keyword",
+                "index": true
+            },
+            "page_urlfragment": {
+                "type": "keyword",
+                "index": true
+            },
+            "page_urlhost": {
+                "type": "keyword",
+                "index": true
+            },
+            "page_urlpath": {
+                "type": "keyword",
+                "index": true
+            },
+            "page_urlport": {
+                "type": "long"
+            },
+            "page_urlquery": {
+                "type": "keyword",
+                "index": true
+            },
+            "page_urlscheme": {
+                "type": "keyword",
+                "index": true
+            },
+            "platform": {
+                "type": "keyword",
+                "index": true
+            },
+            "pp_xoffset_max": {
+                "type": "long"
+            },
+            "pp_xoffset_min": {
+                "type": "long"
+            },
+            "pp_yoffset_max": {
+                "type": "long"
+            },
+            "pp_yoffset_min": {
+                "type": "long"
+            },
+            "refr_medium": {
+                "type": "keyword",
+                "index": true
+            },
+            "refr_source": {
+                "type": "keyword",
+                "index": true
+            },
+            "refr_term": {
+                "type": "keyword",
+                "index": true
+            },
+            "refr_urlfragment": {
+                "type": "keyword",
+                "index": true
+            },
+            "refr_urlhost": {
+                "type": "keyword",
+                "index": true
+            },
+            "refr_urlpath": {
+                "type": "keyword",
+                "index": true
+            },
+            "refr_urlport": {
+                "type": "long"
+            },
+            "refr_urlquery": {
+                "type": "keyword",
+                "index": true
+            },
+            "refr_urlscheme": {
+                "type": "keyword",
+                "index": true
+            },
+            "se_action": {
+                "type": "keyword",
+                "index": true
+            },
+            "se_category": {
+                "type": "keyword",
+                "index": true
+            },
+            "se_label": {
+                "type": "keyword",
+                "index": true
+            },
+            "user_fingerprint": {
+                "type": "keyword",
+                "index": true
+            },
+            "user_id": {
+                "type": "keyword",
+                "index": true
+            },
+            "user_ipaddress": {
+                "type": "keyword",
+                "index": true
+            },
+            "useragent": {
+                "type": "keyword",
+                "index": true
+            },
+            "v_collector": {
+                "type": "keyword",
+                "index": true
+            },
+            "v_etl": {
+                "type": "keyword",
+                "index": true
+            },
+            "v_tracker": {
+                "type": "keyword",
+                "index": true
             }
         }
     }

--- a/provisioning/resources/init/create-kibana-indexes.sh
+++ b/provisioning/resources/init/create-kibana-indexes.sh
@@ -4,7 +4,7 @@
 curl -X POST \
   http://localhost:5601/api/saved_objects/index-pattern/good \
   -H 'Content-Type: application/json' \
-  -H 'kbn-xsrf: true' \
+  -H 'osd-xsrf: true' \
   -d '{
   "attributes": {
     "title": "good",
@@ -15,7 +15,7 @@ curl -X POST \
 curl -X POST \
   http://localhost:5601/api/saved_objects/index-pattern/bad \
   -H 'Content-Type: application/json' \
-  -H 'kbn-xsrf: true' \
+  -H 'osd-xsrf: true' \
   -d '{
   "attributes": {
     "title": "bad",
@@ -25,9 +25,9 @@ curl -X POST \
 
 # Set `good` as default index pattern
 curl -X POST \
-  http://localhost:5601/api/kibana/settings/defaultIndex \
+  http://localhost:5601/api/opensearch-dashboards/settings/defaultIndex \
   -H "Content-Type: application/json" \
-  -H "kbn-xsrf: true" \
+  -H "osd-xsrf: true" \
   -d '{
   "value": "good"
 }'

--- a/provisioning/roles/docker/files/docker-compose.yml
+++ b/provisioning/roles/docker/files/docker-compose.yml
@@ -2,17 +2,19 @@ version: "3"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.23
+    image: opensearchproject/opensearch:2.4.0
     container_name: elasticsearch
     restart: always
     environment:
       # Swapping needs to be disabled for performance and node stability
       - "bootstrap.memory_lock=true"
-      - ES_JAVA_OPTS=-Xms${ES_JVM_SIZE} -Xmx${ES_JVM_SIZE}
+      - OPENSEARCH_JAVA_OPTS=-Xms${ES_JVM_SIZE} -Xmx${ES_JVM_SIZE}
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
     volumes:
-      - /home/ubuntu/snowplow/elasticsearch/data:/usr/share/elasticsearch/data
-      - /home/ubuntu/snowplow/elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
-      - /home/ubuntu/snowplow/elasticsearch/config/log4j2.properties:/usr/share/elasticsearch/config/log4j2.properties
+      - /home/ubuntu/snowplow/elasticsearch/data:/usr/share/opensearch/data
+      - /home/ubuntu/snowplow/elasticsearch/config/elasticsearch.yml:/usr/share/opensearch/config/opensearch.yml
+      - /home/ubuntu/snowplow/elasticsearch/config/log4j2.properties:/usr/share/opensearch/config/log4j2.properties
     ulimits:
       memlock:
         soft: -1
@@ -29,11 +31,13 @@ services:
       - "9300:9300"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:6.8.23
+    image: opensearchproject/opensearch-dashboards:2.4.0
     container_name: kibana
     restart: always
+    environment:
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
     volumes:
-      - /home/ubuntu/snowplow/elasticsearch/config/kibana.yml:/usr/share/kibana/config/kibana.yml
+      - /home/ubuntu/snowplow/elasticsearch/config/kibana.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml
     ports:
       - "5601:5601"
     depends_on:
@@ -44,7 +48,7 @@ services:
         max-file: "10"
 
   elasticsearch-loader-good:
-    image: snowplow/elasticsearch-loader:1.0.7
+    image: snowplow/elasticsearch-loader:2.0.8
     container_name: elasticsearch-loader-good
     command: [ "--config", "/snowplow/config/snowplow-es-loader-good.hocon" ]
     restart: always
@@ -60,7 +64,7 @@ services:
       - "JAVA_OPTS=-Xmx${SP_JVM_SIZE} -Dlog4j2.formatMsgNoLookups=true"
 
   elasticsearch-loader-bad:
-    image: snowplow/elasticsearch-loader:1.0.7
+    image: snowplow/elasticsearch-loader:2.0.8
     container_name: elasticsearch-loader-bad
     command: [ "--config", "/snowplow/config/snowplow-es-loader-bad.hocon" ]
     restart: always

--- a/provisioning/roles/sp_mini_3_build_go_projects/tasks/main.yml
+++ b/provisioning/roles/sp_mini_3_build_go_projects/tasks/main.yml
@@ -12,10 +12,10 @@
     PATH: "{{ lookup('env','PATH') }}:{{ go_bin }}"
     GOPATH: "{{ lookup('env', 'GOPATH') }}"
   shell: |
-    /usr/local/go/bin/go get github.com/BurntSushi/toml
-    /usr/local/go/bin/go get gopkg.in/pg.v5
-    /usr/local/go/bin/go get github.com/trustelem/zxcvbn
-    /usr/local/go/bin/go get golang.org/x/crypto/bcrypt
+    until $(/usr/local/go/bin/go get github.com/BurntSushi/toml); do echo "github.com/BurntSushi/toml"; sleep 1; done
+    until $(/usr/local/go/bin/go get gopkg.in/pg.v5); do echo "gopkg.in/pg.v5"; sleep 1; done
+    until $(/usr/local/go/bin/go get github.com/trustelem/zxcvbn); do echo "github.com/trustelem/zxcvbn"; sleep 1; done
+    until $(/usr/local/go/bin/go get golang.org/x/crypto/bcrypt); do echo "golang.org/x/crypto/bcrypt"; sleep 1; done
 
 - name: Build Control Plane API
   become: yes


### PR DESCRIPTION
Since we are trying to deprecate Mini soon, this PR tries to make as minimal changes as possible. Therefore there are lots of places that `elasticsearch` and `kibana` terms are still in use.