### PR TITLE
Add HSTS to caddy configuration

### DIFF
--- a/provisioning/resources/configs/openapi.yaml
+++ b/provisioning/resources/configs/openapi.yaml
@@ -221,9 +221,18 @@ paths:
           description: "Telemetry has been reconfigured"
         "401":
           description: "Unauthorized"
-      
-      
-      
+  /add-hsts:
+    put:
+      tags:
+      - "configuration"
+      summary: "Add HSTS header"
+      description: "Adds HSTS header to underlying caddy configuration. When added, 'Strict-Transport-Security' header is returned for each HTTPS response"
+      operationId: "addHsts"
+      responses:
+        "200":
+          description: "HSTS header has been added"
+        "401":
+          description: "Unauthorized"
       
   /restart-services:
     put:

--- a/provisioning/resources/control-plane/add_hsts_header.go
+++ b/provisioning/resources/control-plane/add_hsts_header.go
@@ -12,28 +12,28 @@ package main
 
 import (
 	"io/ioutil"
-  "strings"
+	"strings"
 )
 
 func addHstsHeader(configPath string) error {
-  currentConfig, err := ioutil.ReadFile(configPath)
+	currentConfig, err := ioutil.ReadFile(configPath)
 
-  if err != nil {
+	if err != nil {
 		return err
 	}
-  toReplacePattern :=
-`
+	toReplacePattern :=
+		`
       handle @isHttps {
         import handleProtectedPaths
       }
 `
-  replaceWithHsts :=
-`
+	replaceWithHsts :=
+		`
       handle @isHttps {
         import handleProtectedPaths
         header Strict-Transport-Security max-age=31536000; includeSubDomains
       }
 `
-  newCaddyConfig := strings.Replace(string(currentConfig), toReplacePattern, replaceWithHsts, 1)
+	newCaddyConfig := strings.Replace(string(currentConfig), toReplacePattern, replaceWithHsts, 1)
 	return ioutil.WriteFile(configPath, []byte(newCaddyConfig), 0644)
 }

--- a/provisioning/resources/control-plane/add_hsts_header.go
+++ b/provisioning/resources/control-plane/add_hsts_header.go
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2024-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package main
+
+import (
+	"io/ioutil"
+  "strings"
+)
+
+func addHstsHeader(configPath string) error {
+  currentConfig, err := ioutil.ReadFile(configPath)
+
+  if err != nil {
+		return err
+	}
+  toReplacePattern :=
+`
+      handle @isHttps {
+        import handleProtectedPaths
+      }
+`
+  replaceWithHsts :=
+`
+      handle @isHttps {
+        import handleProtectedPaths
+        header Strict-Transport-Security max-age=31536000; includeSubDomains
+      }
+`
+  newCaddyConfig := strings.Replace(string(currentConfig), toReplacePattern, replaceWithHsts, 1)
+	return ioutil.WriteFile(configPath, []byte(newCaddyConfig), 0644)
+}

--- a/provisioning/resources/control-plane/add_hsts_header.go
+++ b/provisioning/resources/control-plane/add_hsts_header.go
@@ -31,7 +31,7 @@ func addHstsHeader(configPath string) error {
 		`
       handle @isHttps {
         import handleProtectedPaths
-        header Strict-Transport-Security max-age=31536000; includeSubDomains
+        header Strict-Transport-Security "max-age=31536000; includeSubDomains"
       }
 `
 	newCaddyConfig := strings.Replace(string(currentConfig), toReplacePattern, replaceWithHsts, 1)

--- a/provisioning/resources/control-plane/main.go
+++ b/provisioning/resources/control-plane/main.go
@@ -137,10 +137,15 @@ func addHsts(resp http.ResponseWriter, req *http.Request) {
 		err := addHstsHeader(config.ConfigNames.Caddy)
 		if err != nil {
 			http.Error(resp, err.Error(), 500)
-		} else {
-			resp.WriteHeader(http.StatusOK)
-			io.WriteString(resp, "OK")
+			return
 		}
+		err, status := restartSPService("caddy")
+		if err != nil {
+			http.Error(resp, err.Error(), status)
+			return
+		}
+		resp.WriteHeader(http.StatusOK)
+		io.WriteString(resp, "OK")
 	} else {
 		// Return 404 for other methods
 		http.Error(resp, "", 404)

--- a/provisioning/resources/control-plane/main.go
+++ b/provisioning/resources/control-plane/main.go
@@ -47,6 +47,7 @@ func main() {
 	http.HandleFunc("/version", getSpminiVersion)
 	http.HandleFunc("/telemetry", manageTelemetry)
 	http.HandleFunc("/reset-service", resetService)
+	http.HandleFunc("/add-hsts", addHsts)
 	log.Fatal(http.ListenAndServe(":10000", nil))
 }
 
@@ -128,6 +129,21 @@ func resetService(resp http.ResponseWriter, req *http.Request) {
 	} else {
 		http.Error(resp, "Only POST is supported", 400)
 		return
+	}
+}
+
+func addHsts (resp http.ResponseWriter, req *http.Request) {
+  if req.Method == "PUT" {
+		err := addHstsHeader(config.Dirs.Config+"/"+config.ConfigNames.Caddy)
+		if err != nil {
+			http.Error(resp, err.Error(), 500)
+		} else {
+			resp.WriteHeader(http.StatusOK)
+			io.WriteString(resp, "OK")
+		}
+	} else {
+		// Return 404 for other methods
+		http.Error(resp, "", 404)
 	}
 }
 

--- a/provisioning/resources/control-plane/main.go
+++ b/provisioning/resources/control-plane/main.go
@@ -132,9 +132,9 @@ func resetService(resp http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func addHsts (resp http.ResponseWriter, req *http.Request) {
-  if req.Method == "PUT" {
-		err := addHstsHeader(config.Dirs.Config+"/"+config.ConfigNames.Caddy)
+func addHsts(resp http.ResponseWriter, req *http.Request) {
+	if req.Method == "PUT" {
+		err := addHstsHeader(config.ConfigNames.Caddy)
 		if err != nil {
 			http.Error(resp, err.Error(), 500)
 		} else {


### PR DESCRIPTION
New control-plane endpoint `/add-hsts`, when invoked modifies this part of Caddyfile:

```
:8443 {
    import protectedPaths

    @isHttps {
        header X-Forwarded-Proto https
    }

    route {
      handle @isHttps {
        import handleProtectedPaths
      }
      redir @protectedPaths https://{host}{uri}
    }

    import handleCollector
}
```

to 

```
:8443 {
    import protectedPaths

    @isHttps {
        header X-Forwarded-Proto https
    }

    route {
      handle @isHttps {
        import handleProtectedPaths
        header Strict-Transport-Security max-age=31536000; includeSubDomains
      }
      redir @protectedPaths https://{host}{uri}
    }

    import handleCollector
}
```

So adds `header Strict-Transport-Security max-age=31536000; includeSubDomains` HSTS response header to HTTPS calls.